### PR TITLE
typo

### DIFF
--- a/backend/app/api/routes/cleanings.py
+++ b/backend/app/api/routes/cleanings.py
@@ -18,7 +18,7 @@ async def get_all_cleanings() -> List[dict]:
 
 	return cleanings
 
-@router.post("/", response_model=CleaningPublic, name="cleanings:create-cleanings", status_code=HTTP_201_CREATED)
+@router.post("/", response_model=CleaningPublic, name="cleanings:create-cleaning", status_code=HTTP_201_CREATED)
 async def create_new_cleaning(
 	new_cleaning: CleaningCreate = Body(...,  embed=True),
 	cleanings_repo: CleaningsRepository = Depends(get_repository(CleaningsRepository))


### PR DESCRIPTION
Really sneaky typo. Tests run after changing post function name parameter. Exception `starlette.routing.NoMatchFound` was being raised and that suggested that the post function name and the name used in url_path_for function in the tests wasn't the same.